### PR TITLE
Add a unit test for testing nested relationships with soft deleted records.

### DIFF
--- a/tests/JoinerTest.php
+++ b/tests/JoinerTest.php
@@ -2,6 +2,7 @@
 
 namespace Sofa\Eloquence\Tests;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder as Query;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Eloquent\Model;
@@ -87,6 +88,23 @@ class JoinerTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($sql, $query->toSql());
     }
 
+    /**
+     * @test
+     */
+    public function it_joins_nested_relations_with_soft_delete()
+    {
+        $sql = 'select * from "users" '.
+            'inner join "posts" on "users"."id" = "posts"."user_id" and "posts"."deleted_at" is null '.
+            'inner join "comments" on "posts"."id" = "comments"."post_id" ';
+
+        $query = $this->getQuery();
+        $joiner = $this->factory->make($query);
+
+        $joiner->join('posts.comments');
+
+        $this->assertEquals($sql, $query->toSql());
+    }
+
     public function getQuery()
     {
         $model = new JoinerUserStub;
@@ -155,7 +173,18 @@ class JoinerCompanyStub extends Model {
 }
 
 class JoinerPostStub extends Model {
+    use SoftDeletes;
+
     protected $table = 'posts';
+
+    public function comments()
+    {
+        return $this->hasMany('Sofa\Eloquence\Tests\JoinerCommentStub', 'post_id');
+    }
+}
+
+class JoinerCommentStub extends Model {
+    protected $table = 'comments';
 }
 
 class MorphOneStub extends Model {


### PR DESCRIPTION
Added the requested unit test as was requested in https://github.com/jarektkaczyk/eloquence/issues/220. If you don't like the idea of filtering out deleted records inside of a `join` then a way to exclude softly deleted records would be adding `'where "posts"."deleted_at" is null ';` at the end of the statement.

I also thought it might make sense to have a sort of `withTrashed` scope that would enable search across deleted records. Let me know your thoughts about it, I'll also be thinking about a better way to do it if it at least makes sense...