### PR TITLE
Fix the foreign key name  for laravel version < 5.8

### DIFF
--- a/src/Relations/Joiner.php
+++ b/src/Relations/Joiner.php
@@ -194,7 +194,10 @@ class Joiner implements JoinerContract
         }
 
         if ($relation instanceof BelongsTo) {
-            return [$relation->getQualifiedForeignKeyName(), $relation->getQualifiedOwnerKeyName()];
+            $qualifiedForeighKeyName = method_exists($relation, 'getQualifiedForeignKeyName') ?
+                $relation->getQualifiedForeignKeyName() : $relation->getQualifiedForeignKey();
+
+            return [$qualifiedForeighKeyName, $relation->getQualifiedOwnerKeyName()];
         }
 
         if ($relation instanceof BelongsToMany) {


### PR DESCRIPTION
Before Laravel 5.8 the BelongsTo relationship didn't have getQualifiedForeignKeyName method, it was called getQualifiedForeignKey.

To reproduce the error without installing the package in a Laravel application, downgrade the laravel package versions to <5.8:

`composer require illuminate/database:5.7.* illuminate/container:5.7.* illuminate/contracts:5.7.* illuminate/support:5.7.*`

This will make the JoinerTests fail, because of the missing method call.

This PR fixes #12 