### PR TITLE
Observe only if instance of CleansAttributes

### DIFF
--- a/src/AttributeCleaner/Observer.php
+++ b/src/AttributeCleaner/Observer.php
@@ -14,9 +14,7 @@ class Observer
      */
     public function saving($model)
     {
-        if ($model instanceof CleansAttributes) {
-            $this->cleanAttributes($model);
-        }
+        $this->cleanAttributes($model);
     }
 
     /**

--- a/src/Eloquence.php
+++ b/src/Eloquence.php
@@ -7,6 +7,7 @@ use Sofa\Hookable\Hookable;
 use Sofa\Hookable\Contracts\ArgumentBag;
 use Sofa\Eloquence\Query\Builder as QueryBuilder;
 use Sofa\Eloquence\AttributeCleaner\Observer as AttributeCleaner;
+use Sofa\Eloquence\Contracts\CleansAttributes;
 
 /**
  * This trait is an entry point for all the hooks that we want to apply
@@ -40,7 +41,9 @@ trait Eloquence
      */
     public static function bootEloquence()
     {
-        static::observe(new AttributeCleaner);
+        if (is_subclass_of(static::class, CleansAttributes::class)) {
+            static::observe(new AttributeCleaner);
+        }
     }
 
     /**


### PR DESCRIPTION
Instead of registering observer in every case and then checking if CleansAttributes is implemented on every event, we should register observer only if the model actually implements CleansAttributes.

This way those of us that are not interested in automatic attribute cleaning can simply not implement it without any overhead.